### PR TITLE
fix!: bump tenacity version to not use deprecated decorator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = ["CM000n"]
 python = "~3.9.2"
 homeassistant = "^2022.12"
 questdb = "^1.0.2"
-tenacity = "^5.0.3"
+tenacity = "^6.0.0"
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qss"
-version = "0.0.3"
+version = "0.0.4"
 description = "QuestDB State Storage (QSS) for Home Assistant"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
# Context

I was running into an error importing the component (installed with HACS) as it was reporting an issue with an `asyncio` decorator in `tenacity`:
![image](https://user-images.githubusercontent.com/16850875/230787902-c601ec99-bebb-4f10-b0a0-bd19ea0a7772.png)

My `python` version is 3.11 and these are some of the other package versions at the time:
```
Package                    Version
-------------------------- ----------
...
homeassistant              2023.4.2
...
questdb                    1.1.0
...
tenacity                   5.1.5
…
```

# Actual change

Just a bump to the `tenacity` dependency to make it new enough that the problem is solved but not so new that there are other breaking changes (>7 seemed to break in a different way but >6 seems like the right place to be)

My installation is now using `tenacity==6.3.1` and I haven’t got any more errors and my `QuestDB` seems to be receiving data 🥳 