### PR TITLE
Fix Python3.11 compatibility

### DIFF
--- a/custom_components/qss/manifest.json
+++ b/custom_components/qss/manifest.json
@@ -10,7 +10,7 @@
     "issue_tracker": "https://github.com/CM000n/QSS/issues",
     "requirements": [
         "questdb>=1.0,<2.0",
-        "tenacity>=5.0,<6.0"
+        "tenacity>=8.0"
     ],
     "version": "0.0.1"
 }


### PR DESCRIPTION
This commit addresses the issue that certain async language constructs were deprecated with Python:3.10 and removed within Python:3.11. As a result, qss was disfunctional in the Homeassistant:2023.6 which just switched to Python:3.11.

The "tenacity" dependency addressed the async language constructs in their version 8  language constructs in their version 8.