### PR TITLE
Adds ability to store attributes in their own columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ qss:
 (map)(Required)
 Enables the qss integration. Only allowed once.
 
+  split_attributes:
+  (bool)(Optional)
+  If set to "true", stores each event attribute in its own column. Otherwise, stores all attributes as a dict in the "attrs" column. (Defaults to False)
+
   host:
   (string)(Required)
   The URL or IP Address that points to your QuestDB database.

--- a/custom_components/qss/__init__.py
+++ b/custom_components/qss/__init__.py
@@ -160,7 +160,7 @@ class QuestDB(threading.Thread):  # pylint: disable = R0902
         while True:
             event = get_event_from_queue(self.queue)
             finish_task_if_empty_event(event, self.queue)
-            insert_event_data_into_questdb(self.host, self.port, self.auth, event, self.queue)
+            insert_event_data_into_questdb(self.host, self.port, self.auth, event, self.queue, self.split_attributes)
 
     @callback
     def event_listener(self, event: Event):

--- a/custom_components/qss/const.py
+++ b/custom_components/qss/const.py
@@ -13,6 +13,8 @@ CONF_AUTH_D_KEY = "d_key"
 CONF_AUTH_X_KEY = "x_key"
 CONF_AUTH_Y_KEY = "y_key"
 
+CONF_SPLIT_ATTRIBUTES = "split_attributes"
+
 RETRY_WAIT_SECONDS = 5
 RETRY_ATTEMPTS = 10
 

--- a/custom_components/qss/io.py
+++ b/custom_components/qss/io.py
@@ -16,13 +16,11 @@ def _insert_row_with_auth(host: str, port: int, auth: tuple, event: Event, split
     with Sender(host, port, auth=auth, tls=True) as sender:
         entity_id = event.data["entity_id"]
         state = event.data.get("new_state")
-        attrs = dumps(dict(state.attributes), sort_keys=True, default=str)
-        columns = {"state": state}
+        columns = {"state": state.state}
         if split_attributes:
-            columns.update(loads(attrs))
+            columns.update(state.attributes)
         else:
-            columns["attrs"] = attrs
-
+            columns["attrs"] = dumps(dict(state.attributes), sort_keys=True, default=str)
         sender.row(
             "qss",
             symbols={
@@ -39,12 +37,11 @@ def _insert_row_without_auth(host: str, port: int, event: Event, split_attribute
     with Sender(host, port) as sender:
         entity_id = event.data["entity_id"]
         state = event.data.get("new_state")
-        attrs = dumps(dict(state.attributes), sort_keys=True, default=str)
-        columns = {"state": state}
+        columns = {"state": state.state}
         if split_attributes:
-            columns.update(loads(attrs))
+            columns.update(state.attributes)
         else:
-            columns["attrs"] = attrs
+            columns["attrs"] = dumps(dict(state.attributes), sort_keys=True, default=str)
         sender.row(
             "qss",
             symbols={

--- a/custom_components/qss/io.py
+++ b/custom_components/qss/io.py
@@ -1,6 +1,6 @@
 """Helper functions for IO operations on QuestDB."""
 import logging
-from json import dumps
+from json import dumps, loads
 from queue import Queue
 
 from homeassistant.core import Event
@@ -16,10 +16,10 @@ def _insert_row_with_auth(host: str, port: int, auth: tuple, event: Event, split
     with Sender(host, port, auth=auth, tls=True) as sender:
         entity_id = event.data["entity_id"]
         state = event.data.get("new_state")
-        attrs = dict(state.attributes)
+        attrs = dumps(dict(state.attributes), sort_keys=True, default=str)
         columns = {"state": state}
         if split_attributes:
-            columns.update(attrs)
+            columns.update(loads(attrs))
         else:
             columns["attrs"] = attrs
 
@@ -39,13 +39,12 @@ def _insert_row_without_auth(host: str, port: int, event: Event, split_attribute
     with Sender(host, port) as sender:
         entity_id = event.data["entity_id"]
         state = event.data.get("new_state")
-        attrs = dict(state.attributes)
+        attrs = dumps(dict(state.attributes), sort_keys=True, default=str)
         columns = {"state": state}
         if split_attributes:
-            columns.update(attrs)
+            columns.update(loads(attrs))
         else:
             columns["attrs"] = attrs
-
         sender.row(
             "qss",
             symbols={

--- a/custom_components/qss/io.py
+++ b/custom_components/qss/io.py
@@ -1,6 +1,6 @@
 """Helper functions for IO operations on QuestDB."""
 import logging
-from json import dumps, loads
+from json import dumps
 from queue import Queue
 
 from homeassistant.core import Event


### PR DESCRIPTION
First of all, thanks for this project! As someone who works for QuestDB and also just bought a house, this has been a lifesaver for me in starting my homeassistant journey!

Since our ILP protocol creates columns when it encounters unknowns, I figured that it might be useful to split out the `attributes` column into multiple columns for easier querying purposes. I left the default behavior the same, just added the `split_attributes` config option.

This is running successfully on my homeassistant, but I'm happy to keep this running for a little bit to ensure its stability.

---

**EDIT**: Ah, and I already hit an issue with a `list` value :-(   Maybe unstructured storage is the way to go here for now