### PR TITLE
Update to qestdb 2.0.3 API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           inputs: ${{ github.workspace }}/custom_components/qss/qss.zip
 
       - name: ⬆️ Upload zip to release
-        uses: softprops/action-gh-release@v2.0.9
+        uses: softprops/action-gh-release@v2.1.0
         with:
           files: ${{ github.workspace }}/custom_components/qss/qss.zip
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           inputs: ${{ github.workspace }}/custom_components/qss/qss.zip
 
       - name: ⬆️ Upload zip to release
-        uses: softprops/action-gh-release@v2.0.8
+        uses: softprops/action-gh-release@v2.0.9
         with:
           files: ${{ github.workspace }}/custom_components/qss/qss.zip
 

--- a/custom_components/qss/const.py
+++ b/custom_components/qss/const.py
@@ -14,7 +14,7 @@ CONF_AUTH_X_KEY = "x_key"
 CONF_AUTH_Y_KEY = "y_key"
 
 RETRY_WAIT_SECONDS = 5
-RETRY_ATTEMPTS = 10
+RETRY_ATTEMPTS = 150
 
 STARTUP_MESSAGE = f"""
 -------------------------------------------------------------------

--- a/custom_components/qss/event_handling.py
+++ b/custom_components/qss/event_handling.py
@@ -10,8 +10,9 @@ def put_event_to_queue(event: Event, entity_filter: Callable[[str], bool], queue
     """Get events with new states and put them in the process queue."""
     entity_id = event.data.get(ATTR_ENTITY_ID)
     state = event.data.get("new_state")
-    if all([entity_id, state, state.state != STATE_UNKNOWN, entity_filter(entity_id)]):
-        queue.put(event)
+    if state is not None:
+        if all([entity_id, state, state.state != STATE_UNKNOWN, entity_filter(entity_id)]):
+            queue.put(event)
 
 
 def get_event_from_queue(queue: Queue) -> Event:

--- a/custom_components/qss/io.py
+++ b/custom_components/qss/io.py
@@ -4,7 +4,7 @@ from json import dumps
 from queue import Queue
 
 from homeassistant.core import Event
-from questdb.ingress import IngressError, Sender
+from questdb.ingress import IngressError, Protocol, Sender
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 from .const import RETRY_ATTEMPTS, RETRY_WAIT_SECONDS
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _insert_row_with_auth(host: str, port: int, auth: tuple, event: Event) -> None:
-    with Sender(host, port, auth=auth, tls=True) as sender:
+    with Sender(Protocol.Tcps, host, port, username=auth[0], token=auth[1], token_x=auth[2], token_y=auth[3]) as sender:
         entity_id = event.data["entity_id"]
         state = event.data.get("new_state")
         attrs = dict(state.attributes)
@@ -33,7 +33,7 @@ def _insert_row_with_auth(host: str, port: int, auth: tuple, event: Event) -> No
 
 
 def _insert_row_without_auth(host: str, port: int, event: Event) -> None:
-    with Sender(host, port) as sender:
+    with Sender(Protocol.Tcp, host, port) as sender:
         entity_id = event.data["entity_id"]
         state = event.data.get("new_state")
         attrs = dict(state.attributes)

--- a/custom_components/qss/manifest.json
+++ b/custom_components/qss/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/CM000n/QSS",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/CM000n/QSS/issues",
-  "requirements": ["questdb>=1.2,<2.0", "tenacity>=8.0"],
-  "version": "v0.0.10"
+  "requirements": ["questdb>=2.0.3", "tenacity>=8.0"],
+  "version": "v0.0.11"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qss"
-version = "v0.0.10"
+version = "v0.0.11"
 description = "QuestDB State Storage (QSS) for Home Assistant"
 authors = ["CM000n"]
 keywords = [
@@ -17,14 +17,14 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-homeassistant = "^2023.12"
-questdb = "^1.2.0"
+homeassistant = "^2024.12"
+questdb = "^2.0.3"
 tenacity = "^8.0.0"
 
 
 [tool.poetry.dev-dependencies]
 voluptuous-stubs = "^0.1"
-homeassistant-stubs = "^2023.12"
+homeassistant-stubs = "^2024.12"
 pre-commit = "^2.21.0"
 pre-commit-hooks = "^4.5.0"
 codespell = "^2.0.0"


### PR DESCRIPTION
This implements qestdb-2.0 API and lift qestdb dependancy to questdb==2.0.3, as only 2.0.3 version of questdb python module client can be build by pip from sources (if Rust compiler "cargo" is installed).
Earlier versions have bugs here and there and PIP can not build them.
Also, it is much easier  to convince questdb people to provide binaries (to avoid building altogether)  for recent client, than for old one.