### PR TITLE
Use a persistent, reused QuestDB connection with periodic batched flushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ Enables the qss integration. Only allowed once.
   (string)(Optional)
   The name of the QuestDB table QSS should store the state data in. Defaults to `qss`. Useful if you want to keep multiple Home Assistant instances or environments separated within the same QuestDB.
 
+  max_batch_size:
+  (int)(Optional)
+  QSS keeps a single, persistent connection to QuestDB open and reuses it for many events instead of opening a new connection per event. Rows are buffered and only sent to QuestDB once this many rows have accumulated (or once `flush_interval_seconds` has elapsed, whichever happens first). Defaults to `500`.
+
+  flush_interval_seconds:
+  (int)(Optional)
+  The maximum number of seconds buffered rows may stay unflushed before being sent to QuestDB, even if `max_batch_size` has not yet been reached. Defaults to `5`.
+
   authentication:
   (dict)(Optional)
   Under this entry you can, if desired, enter the authenication parameters necessary for your Quest DB installation. The entry is completely optional if your Quest DB installation does not have any additional authentication settings. Keep in mind that this authentication needs an SSL setup, either from QuestDB Enterprise or a reverse proxy.

--- a/custom_components/qss/__init__.py
+++ b/custom_components/qss/__init__.py
@@ -27,18 +27,28 @@ from .const import (
     CONF_AUTH_SSL_CHECK,
     CONF_AUTH_X_KEY,
     CONF_AUTH_Y_KEY,
+    CONF_FLUSH_INTERVAL_SECONDS,
     CONF_HOST,
+    CONF_MAX_BATCH_SIZE,
     CONF_PORT,
     CONF_TABLE_NAME,
+    DEFAULT_FLUSH_INTERVAL_SECONDS,
+    DEFAULT_MAX_BATCH_SIZE,
     DEFAULT_TABLE_NAME,
     DOMAIN,
 )
 from .event_handling import (
+    QUEUE_POLL_TIMEOUT,
     finish_task_if_empty_event,
     get_event_from_queue,
     put_event_to_queue,
 )
-from .io import QuestDBAuth, QuestDBConfig, insert_event_data_into_questdb
+from .io import (
+    QuestDBAuth,
+    QuestDBConfig,
+    QuestDBConnection,
+    insert_event_data_into_questdb,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -66,6 +76,12 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Required(CONF_HOST): cv.string,
                 vol.Required(CONF_PORT): cv.positive_int,
                 vol.Optional(CONF_TABLE_NAME, default=DEFAULT_TABLE_NAME): cv.string,
+                vol.Optional(
+                    CONF_MAX_BATCH_SIZE, default=DEFAULT_MAX_BATCH_SIZE
+                ): cv.positive_int,
+                vol.Optional(
+                    CONF_FLUSH_INTERVAL_SECONDS, default=DEFAULT_FLUSH_INTERVAL_SECONDS
+                ): cv.positive_int,
                 vol.Optional(CONF_AUTH, default={}): AUTHENTICATION_SCHEMA,
             }
         )
@@ -81,6 +97,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     db_host = str(conf.get(CONF_HOST))
     db_port = int(conf.get(CONF_PORT))
     db_table_name = str(conf.get(CONF_TABLE_NAME))
+    db_max_batch_size = int(conf.get(CONF_MAX_BATCH_SIZE))
+    db_flush_interval_seconds = int(conf.get(CONF_FLUSH_INTERVAL_SECONDS))
 
     entity_filter = convert_include_exclude_filter(conf)
 
@@ -92,7 +110,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         ssl_check=conf.get(CONF_AUTH).get(CONF_AUTH_SSL_CHECK),
     )
     db_config = QuestDBConfig(
-        host=db_host, port=db_port, table_name=db_table_name, auth=db_auth
+        host=db_host,
+        port=db_port,
+        table_name=db_table_name,
+        auth=db_auth,
+        max_batch_size=db_max_batch_size,
+        flush_interval_seconds=db_flush_interval_seconds,
     )
 
     instance = QuestDB(hass=hass, entity_filter=entity_filter, config=db_config)
@@ -167,13 +190,29 @@ class QuestDB(threading.Thread):  # pylint: disable = R0902
         if result is shutdown_task:
             return
 
-        while True:
-            event = get_event_from_queue(self.queue)
-            finish_task_if_empty_event(event, self.queue)
-            # Check if shutdown is in progress
-            if self.shutdown_event.is_set():
-                break
-            insert_event_data_into_questdb(self.config, event, self.queue)
+        # A single, long-lived connection is reused across all events instead
+        # of opening a new one per event. The `finally` guarantees any
+        # buffered-but-unflushed rows are flushed and the connection is
+        # closed cleanly on every exit path, including shutdown.
+        connection = QuestDBConnection(self.config)
+        try:
+            while True:
+                event = get_event_from_queue(
+                    self.queue, timeout=self.config.flush_interval_seconds
+                )
+                finish_task_if_empty_event(event, self.queue)
+                # Check if shutdown is in progress
+                if self.shutdown_event.is_set():
+                    break
+                if event is QUEUE_POLL_TIMEOUT:
+                    # No new event arrived within the flush interval: flush
+                    # any buffered rows so they don't sit unflushed for long
+                    # during quiet periods.
+                    connection.flush_if_due()
+                    continue
+                insert_event_data_into_questdb(connection, event, self.queue)
+        finally:
+            connection.close()
 
     @callback
     def event_listener(self, event: Event) -> None:

--- a/custom_components/qss/const.py
+++ b/custom_components/qss/const.py
@@ -7,8 +7,12 @@ ISSUES_URL = "https://github.com/CM000n/qss/issues"
 CONF_HOST = "host"
 CONF_PORT = "port"
 CONF_TABLE_NAME = "table_name"
+CONF_MAX_BATCH_SIZE = "max_batch_size"
+CONF_FLUSH_INTERVAL_SECONDS = "flush_interval_seconds"
 
 DEFAULT_TABLE_NAME = "qss"
+DEFAULT_MAX_BATCH_SIZE = 500
+DEFAULT_FLUSH_INTERVAL_SECONDS = 5
 
 CONF_AUTH = "authentication"
 CONF_AUTH_SSL_CHECK = "ssl_check"

--- a/custom_components/qss/event_handling.py
+++ b/custom_components/qss/event_handling.py
@@ -1,5 +1,6 @@
 """Helper functions for event handling and data insertion."""
 
+from queue import Empty
 from typing import TYPE_CHECKING
 
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
@@ -9,6 +10,14 @@ if TYPE_CHECKING:
     from queue import Queue
 
     from homeassistant.core import Event
+
+QUEUE_POLL_TIMEOUT = object()
+"""Sentinel returned by :func:`get_event_from_queue` when a poll times out.
+
+Distinct from the ``None`` value that is put onto the queue to signal
+shutdown, so callers can tell "no event arrived within ``timeout`` seconds"
+apart from "the queue is being shut down".
+"""
 
 
 def put_event_to_queue(
@@ -23,9 +32,20 @@ def put_event_to_queue(
         queue.put(event)
 
 
-def get_event_from_queue(queue: Queue) -> Event:
-    """Return event from process queue."""
-    return queue.get()
+def get_event_from_queue(
+    queue: Queue, timeout: float | None = None
+) -> Event | object | None:
+    """Return event from process queue.
+
+    If ``timeout`` is given and neither a real event nor the shutdown
+    sentinel (``None``) arrives within that time, ``QUEUE_POLL_TIMEOUT`` is
+    returned instead, so callers can perform periodic housekeeping (such as
+    time-based flushing) without blocking indefinitely.
+    """
+    try:
+        return queue.get(timeout=timeout)
+    except Empty:
+        return QUEUE_POLL_TIMEOUT
 
 
 def finish_task_if_empty_event(event: Event, queue: Queue) -> None:

--- a/custom_components/qss/io.py
+++ b/custom_components/qss/io.py
@@ -3,12 +3,19 @@
 import logging
 from dataclasses import dataclass, field
 from json import dumps
+from time import monotonic
 from typing import TYPE_CHECKING
 
 from questdb.ingress import IngressError, Protocol, Sender
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
-from .const import DEFAULT_TABLE_NAME, RETRY_ATTEMPTS, RETRY_WAIT_SECONDS
+from .const import (
+    DEFAULT_FLUSH_INTERVAL_SECONDS,
+    DEFAULT_MAX_BATCH_SIZE,
+    DEFAULT_TABLE_NAME,
+    RETRY_ATTEMPTS,
+    RETRY_WAIT_SECONDS,
+)
 
 if TYPE_CHECKING:
     from queue import Queue
@@ -37,6 +44,8 @@ class QuestDBConfig:
     port: int
     table_name: str = DEFAULT_TABLE_NAME
     auth: QuestDBAuth = field(default_factory=QuestDBAuth)
+    max_batch_size: int = DEFAULT_MAX_BATCH_SIZE
+    flush_interval_seconds: float = DEFAULT_FLUSH_INTERVAL_SECONDS
 
 
 def _create_sender(config: QuestDBConfig) -> Sender:
@@ -57,7 +66,12 @@ def _create_sender(config: QuestDBConfig) -> Sender:
 
 
 def _insert_row(sender: Sender, event: Event, table_name: str) -> None:
-    """Insert a single row using the provided sender."""
+    """Buffer a single row on the provided sender without flushing it.
+
+    Flushing is the caller's responsibility, so that many rows can be
+    buffered and sent to QuestDB together instead of one row per network
+    round-trip.
+    """
     entity_id = event.data["entity_id"]
     state = event.data.get("new_state")
     attrs = dict(state.attributes)
@@ -70,27 +84,137 @@ def _insert_row(sender: Sender, event: Event, table_name: str) -> None:
         },
         at=event.time_fired,
     )
-    sender.flush()
 
 
-@retry(
-    stop=stop_after_attempt(RETRY_ATTEMPTS),
-    wait=wait_fixed(RETRY_WAIT_SECONDS),
-    retry=retry_if_exception_type(IngressError),
-)
-def _retry_data_insertion(config: QuestDBConfig, event: Event) -> None:
-    """Use a retry for inserting event data into QuestDB."""
-    with _create_sender(config) as sender:
-        _insert_row(sender, event, config.table_name)
+class QuestDBConnection:
+    """Manage a single, long-lived QuestDB ``Sender`` connection.
+
+    Instead of opening and closing a new connection for every event, a single
+    connection is created lazily on the first buffered row and reused across
+    many events. Rows are only flushed to QuestDB once ``max_batch_size`` rows
+    have been buffered, or once ``flush_interval_seconds`` have elapsed since
+    the last flush, whichever happens first. On a transient ``IngressError``
+    the (possibly broken) connection is dropped and lazily recreated before
+    the next retry attempt.
+    """
+
+    def __init__(self, config: QuestDBConfig) -> None:
+        """Initialize the connection wrapper for the given configuration."""
+        self._config = config
+        self._sender: Sender | None = None
+        self._pending_rows = 0
+        self._last_flush_monotonic = monotonic()
+
+    @property
+    def config(self) -> QuestDBConfig:
+        """Return the configuration this connection was created with."""
+        return self._config
+
+    def insert_event(self, event: Event) -> None:
+        """Buffer ``event`` as a row, retrying with reconnection on failure."""
+        self._insert_with_retry(event)
+
+    def flush_if_due(self) -> None:
+        """Flush buffered rows if the configured flush interval has elapsed.
+
+        Intended to be called from the background thread's idle poll (i.e.
+        when no new event arrived within ``flush_interval_seconds``), so that
+        buffered rows are not held indefinitely in memory during quiet
+        periods.
+
+        Unlike :meth:`insert_event`, a failure here is not retried: there is
+        no new event to re-buffer on a fresh connection, so the rows already
+        buffered on a now-broken sender cannot be recovered. The failure is
+        logged and the connection is dropped so the next event lazily
+        reconnects.
+        """
+        if self._pending_rows and self._interval_elapsed():
+            try:
+                self._flush()
+            except IngressError:
+                _LOGGER.exception(
+                    "Failed to flush buffered rows to QuestDB; the buffered "
+                    "rows were lost and the connection will be re-established."
+                )
+                self._reconnect()
+
+    def close(self) -> None:
+        """Flush any buffered rows and close the underlying connection.
+
+        Safe to call even if no event was ever processed (no connection was
+        ever created). Best-effort: any error while flushing/closing is
+        logged rather than raised, so that shutdown is never blocked.
+        """
+        if self._sender is None:
+            return
+        sender, self._sender = self._sender, None
+        self._pending_rows = 0
+        try:
+            sender.close(flush=True)
+        except IngressError:
+            _LOGGER.exception(
+                "Failed to flush buffered rows while closing the QuestDB connection."
+            )
+
+    def _ensure_sender(self) -> Sender:
+        """Lazily create and establish the underlying sender connection."""
+        if self._sender is None:
+            sender = _create_sender(self._config)
+            sender.establish()
+            self._sender = sender
+        return self._sender
+
+    def _reconnect(self) -> None:
+        """Drop the current (possibly broken) sender.
+
+        The next use lazily creates a fresh one. Any rows buffered on the
+        dropped sender are lost, matching the previous per-event behaviour
+        where a failed connection meant the in-flight event's data was lost.
+        """
+        self._sender = None
+        self._pending_rows = 0
+
+    def _buffer_and_maybe_flush(self, event: Event) -> None:
+        """Buffer ``event`` as a row, flushing once the batch size is hit."""
+        sender = self._ensure_sender()
+        _insert_row(sender, event, self._config.table_name)
+        self._pending_rows += 1
+        if self._pending_rows >= self._config.max_batch_size:
+            self._flush()
+
+    def _flush(self) -> None:
+        """Flush the underlying sender and reset the batching state."""
+        if self._sender is not None:
+            self._sender.flush()
+        self._pending_rows = 0
+        self._last_flush_monotonic = monotonic()
+
+    def _interval_elapsed(self) -> bool:
+        """Return whether ``flush_interval_seconds`` have passed since flush."""
+        elapsed = monotonic() - self._last_flush_monotonic
+        return elapsed >= self._config.flush_interval_seconds
+
+    @retry(
+        stop=stop_after_attempt(RETRY_ATTEMPTS),
+        wait=wait_fixed(RETRY_WAIT_SECONDS),
+        retry=retry_if_exception_type(IngressError),
+    )
+    def _insert_with_retry(self, event: Event) -> None:
+        """Buffer a row, reconnecting before each retry attempt on failure."""
+        try:
+            self._buffer_and_maybe_flush(event)
+        except IngressError:
+            self._reconnect()
+            raise
 
 
 def insert_event_data_into_questdb(
-    config: QuestDBConfig, event: Event, queue: Queue
+    connection: QuestDBConnection, event: Event, queue: Queue
 ) -> None:
-    """Insert given event data into QuestDB using a context-managed sender."""
+    """Insert given event data into QuestDB using the shared, persistent connection."""
     try:
         _LOGGER.debug("Inserting event: %s", event)
-        _retry_data_insertion(config, event)
+        connection.insert_event(event)
     except IngressError:
         _LOGGER.exception("Failed to insert event data into QuestDB.")
     queue.task_done()

--- a/tests/test_event_handling.py
+++ b/tests/test_event_handling.py
@@ -7,6 +7,7 @@ import queue
 from homeassistant.const import STATE_UNKNOWN
 
 from custom_components.qss.event_handling import (
+    QUEUE_POLL_TIMEOUT,
     finish_task_if_empty_event,
     get_event_from_queue,
     put_event_to_queue,
@@ -62,6 +63,13 @@ def test_get_event_from_queue_returns_queued_event() -> None:
     event_queue.put(event)
 
     assert get_event_from_queue(event_queue) is event
+
+
+def test_get_event_from_queue_returns_timeout_sentinel_when_empty() -> None:
+    """Polling an empty queue with a timeout should return the timeout sentinel."""
+    event_queue: queue.Queue = queue.Queue()
+
+    assert get_event_from_queue(event_queue, timeout=0.01) is QUEUE_POLL_TIMEOUT
 
 
 def test_finish_task_if_empty_event_marks_task_done_for_none() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
 from collections.abc import Callable
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import voluptuous as vol
@@ -14,7 +15,11 @@ from homeassistant.helpers.entityfilter import convert_include_exclude_filter
 from homeassistant.setup import async_setup_component
 
 from custom_components.qss import CONFIG_SCHEMA, QuestDB
-from custom_components.qss.const import DOMAIN
+from custom_components.qss.const import (
+    DEFAULT_FLUSH_INTERVAL_SECONDS,
+    DEFAULT_MAX_BATCH_SIZE,
+    DOMAIN,
+)
 from custom_components.qss.io import QuestDBConfig
 
 MINIMAL_CONFIG = {DOMAIN: {"host": "localhost", "port": 9009}}
@@ -31,8 +36,8 @@ def mock_insert() -> Callable:
     processed = threading.Event()
     calls: list[tuple] = []
 
-    def _fake_insert(config, event, event_queue) -> None:  # noqa: ANN001
-        calls.append((config, event))
+    def _fake_insert(connection, event, event_queue) -> None:  # noqa: ANN001
+        calls.append((connection, event))
         event_queue.task_done()
         processed.set()
 
@@ -73,9 +78,9 @@ async def test_included_entity_state_change_is_forwarded(
 
     assert mock_insert.processed.wait(timeout=5)
     assert len(mock_insert.calls) == 1
-    config, event = mock_insert.calls[0]
+    connection, event = mock_insert.calls[0]
     assert event.data["entity_id"] == "sensor.temperature"
-    assert config.table_name == "qss"
+    assert connection.config.table_name == "qss"
 
 
 async def test_excluded_domain_state_change_is_not_forwarded(
@@ -114,8 +119,8 @@ async def test_custom_table_name_is_forwarded_to_io_layer(
     await hass.async_block_till_done()
 
     assert mock_insert.processed.wait(timeout=5)
-    config, _ = mock_insert.calls[0]
-    assert config.table_name == "my_custom_table"
+    connection, _ = mock_insert.calls[0]
+    assert connection.config.table_name == "my_custom_table"
 
 
 async def test_thread_exits_cleanly_when_hass_stops_before_starting(
@@ -144,6 +149,90 @@ async def test_thread_exits_cleanly_when_hass_stops_before_starting(
 
     instance.join(timeout=5)
     assert not instance.is_alive()
+
+
+async def test_flush_on_shutdown_flushes_and_closes_sender(hass: HomeAssistant) -> None:
+    """Buffered rows must be flushed and the connection closed on shutdown.
+
+    Uses a very large ``flush_interval_seconds`` so the only flush that can
+    happen is the one triggered by the shutdown path, not the idle poll.
+    """
+    sender = MagicMock()
+    config = {
+        DOMAIN: {
+            "host": "localhost",
+            "port": 9009,
+            "flush_interval_seconds": 3600,
+            "include": {"domains": ["sensor"]},
+        }
+    }
+
+    with patch("custom_components.qss.io._create_sender", return_value=sender):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+        hass.states.async_set("sensor.temperature", "21.5")
+        await hass.async_block_till_done()
+
+        # Give the background thread a brief moment to pick up the queued
+        # event before triggering shutdown.
+        for _ in range(50):
+            if sender.row.called:
+                break
+            await asyncio.sleep(0.1)
+        assert sender.row.called
+        sender.flush.assert_not_called()
+
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
+
+    sender.close.assert_called_once_with(flush=True)
+
+
+async def test_idle_poll_flushes_buffered_rows_via_flush_interval(
+    hass: HomeAssistant,
+) -> None:
+    """When idle, the background thread must flush buffered rows itself.
+
+    Exercises the ``QUEUE_POLL_TIMEOUT`` branch of ``QuestDB.run`` by using a
+    very small ``flush_interval_seconds`` and a large ``max_batch_size`` so
+    the only way to flush is via the idle poll timeout, not the batch-size
+    threshold.
+    """
+    sender = MagicMock()
+    config = {
+        DOMAIN: {
+            "host": "localhost",
+            "port": 9009,
+            "flush_interval_seconds": 1,
+            "max_batch_size": 1000,
+            "include": {"domains": ["sensor"]},
+        }
+    }
+
+    with patch("custom_components.qss.io._create_sender", return_value=sender):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+        hass.states.async_set("sensor.temperature", "21.5")
+        await hass.async_block_till_done()
+
+        for _ in range(50):
+            if sender.row.called:
+                break
+            await asyncio.sleep(0.1)
+        assert sender.row.called
+        sender.flush.assert_not_called()
+
+        for _ in range(50):
+            if sender.flush.called:
+                break
+            await asyncio.sleep(0.1)
+
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
+
+    sender.flush.assert_called_once()
 
 
 def test_config_schema_requires_host_and_port() -> None:
@@ -206,3 +295,28 @@ def test_config_schema_accepts_full_configuration() -> None:
     assert config[DOMAIN]["host"] == "192.168.178.3"
     assert config[DOMAIN]["port"] == 9009
     assert config[DOMAIN]["authentication"]["kid"] == "my_kid"
+
+
+def test_config_schema_defaults_batching_settings() -> None:
+    """Omitting the batching settings should fall back to their defaults."""
+    config = CONFIG_SCHEMA(MINIMAL_CONFIG)
+
+    assert config[DOMAIN]["max_batch_size"] == DEFAULT_MAX_BATCH_SIZE
+    assert config[DOMAIN]["flush_interval_seconds"] == DEFAULT_FLUSH_INTERVAL_SECONDS
+
+
+def test_config_schema_accepts_custom_batching_settings() -> None:
+    """Configured batching settings should be preserved as-is."""
+    config = CONFIG_SCHEMA(
+        {
+            DOMAIN: {
+                "host": "localhost",
+                "port": 9009,
+                "max_batch_size": 50,
+                "flush_interval_seconds": 30,
+            }
+        }
+    )
+
+    assert config[DOMAIN]["max_batch_size"] == 50
+    assert config[DOMAIN]["flush_interval_seconds"] == 30

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -12,9 +12,9 @@ from questdb.ingress import IngressError, IngressErrorCode, Protocol
 from custom_components.qss.io import (
     QuestDBAuth,
     QuestDBConfig,
+    QuestDBConnection,
     _create_sender,
     _insert_row,
-    _retry_data_insertion,
     insert_event_data_into_questdb,
 )
 from tests.helpers import make_state_changed_event
@@ -28,6 +28,24 @@ WITH_AUTH_CONFIG = QuestDBConfig(
         kid="kid", d_key="d_key", x_key="x_key", y_key="y_key", ssl_check=False
     ),
 )
+
+
+def _config(**overrides: object) -> QuestDBConfig:
+    """Build a ``QuestDBConfig`` with test-friendly defaults.
+
+    ``max_batch_size`` and ``flush_interval_seconds`` default to large values
+    so a test only triggers a flush when it explicitly wants to exercise that
+    behaviour.
+    """
+    defaults: dict[str, object] = {
+        "host": "localhost",
+        "port": 9009,
+        "table_name": "qss",
+        "max_batch_size": 100,
+        "flush_interval_seconds": 100,
+    }
+    defaults.update(overrides)
+    return QuestDBConfig(**defaults)  # type: ignore[arg-type]
 
 
 @pytest.fixture(autouse=True)
@@ -61,8 +79,8 @@ def test_create_sender_with_auth_uses_tcps_with_credentials() -> None:
     )
 
 
-def test_insert_row_writes_expected_row_and_flushes() -> None:
-    """The sender receives entity_id/state/attributes and is flushed."""
+def test_insert_row_writes_expected_row_without_flushing() -> None:
+    """The sender receives entity_id/state/attributes but is not flushed."""
     sender = MagicMock()
     event = make_state_changed_event(
         "sensor.temperature", "21.5", attributes={"unit_of_measurement": "°C"}
@@ -77,7 +95,7 @@ def test_insert_row_writes_expected_row_and_flushes() -> None:
     assert kwargs["columns"]["state"] == "21.5"
     assert loads(kwargs["columns"]["attributes"]) == {"unit_of_measurement": "°C"}
     assert kwargs["at"] == event.time_fired
-    sender.flush.assert_called_once()
+    sender.flush.assert_not_called()
 
 
 def test_insert_row_uses_configured_table_name() -> None:
@@ -90,45 +108,175 @@ def test_insert_row_uses_configured_table_name() -> None:
     assert sender.row.call_args.args == ("custom_table",)
 
 
-def test_retry_data_insertion_succeeds_on_first_try() -> None:
-    """A working sender should insert the row without any retries."""
+def test_connection_config_property_returns_configured_config() -> None:
+    """The ``config`` property should return the config passed to the constructor."""
+    config = _config()
+
+    connection = QuestDBConnection(config)
+
+    assert connection.config is config
+
+
+def test_connection_creates_sender_lazily() -> None:
+    """No connection should be created until the first event is inserted."""
+    with patch("custom_components.qss.io._create_sender") as create_sender:
+        QuestDBConnection(_config())
+        create_sender.assert_not_called()
+
+
+def test_connection_reuses_sender_across_multiple_events() -> None:
+    """A single established sender must be reused across many events."""
     sender = MagicMock()
-    sender.__enter__.return_value = sender
-    sender.__exit__.return_value = False
-    event = make_state_changed_event("sensor.temperature", "21.5")
+    events = [make_state_changed_event("sensor.temperature", str(i)) for i in range(3)]
+
+    with patch(
+        "custom_components.qss.io._create_sender", return_value=sender
+    ) as create_sender:
+        connection = QuestDBConnection(_config())
+        for event in events:
+            connection.insert_event(event)
+
+    create_sender.assert_called_once_with(connection.config)
+    sender.establish.assert_called_once()
+    assert sender.row.call_count == 3
+    sender.flush.assert_not_called()
+
+
+def test_connection_flushes_once_batch_size_is_reached() -> None:
+    """Reaching ``max_batch_size`` rows must trigger exactly one flush."""
+    sender = MagicMock()
+    events = [make_state_changed_event("sensor.temperature", str(i)) for i in range(2)]
 
     with patch("custom_components.qss.io._create_sender", return_value=sender):
-        _retry_data_insertion(NO_AUTH_CONFIG, event)
+        connection = QuestDBConnection(_config(max_batch_size=2))
+        connection.insert_event(events[0])
+        sender.flush.assert_not_called()
+        connection.insert_event(events[1])
 
-    sender.row.assert_called_once()
     sender.flush.assert_called_once()
 
 
-def test_retry_data_insertion_retries_transient_errors_until_success() -> None:
-    """Transient ``IngressError``s should be retried until the insert succeeds."""
+def test_connection_flush_if_due_flushes_after_interval_elapses() -> None:
+    """A buffered row must be flushed once the flush interval has elapsed."""
+    sender = MagicMock()
+    event = make_state_changed_event("sensor.temperature", "21.5")
+
+    with (
+        patch("custom_components.qss.io._create_sender", return_value=sender),
+        patch("custom_components.qss.io.monotonic", side_effect=[0.0, 10.0, 10.0]),
+    ):
+        connection = QuestDBConnection(_config(flush_interval_seconds=5))
+        connection.insert_event(event)
+        sender.flush.assert_not_called()
+        connection.flush_if_due()
+
+    sender.flush.assert_called_once()
+
+
+def test_connection_flush_if_due_does_nothing_before_interval_elapses() -> None:
+    """No flush should happen before the configured interval has elapsed."""
+    sender = MagicMock()
+    event = make_state_changed_event("sensor.temperature", "21.5")
+
+    with (
+        patch("custom_components.qss.io._create_sender", return_value=sender),
+        patch("custom_components.qss.io.monotonic", side_effect=[0.0, 2.0]),
+    ):
+        connection = QuestDBConnection(_config(flush_interval_seconds=5))
+        connection.insert_event(event)
+        connection.flush_if_due()
+
+    sender.flush.assert_not_called()
+
+
+def test_connection_flush_if_due_does_nothing_without_pending_rows() -> None:
+    """Calling ``flush_if_due`` with nothing buffered must not create a connection."""
+    with patch("custom_components.qss.io._create_sender") as create_sender:
+        connection = QuestDBConnection(_config())
+        connection.flush_if_due()
+
+    create_sender.assert_not_called()
+
+
+def test_connection_flush_if_due_reconnects_after_ingress_error() -> None:
+    """A flush failure must be logged, and the connection reset, not raised."""
+    sender = MagicMock()
+    sender.flush.side_effect = IngressError(IngressErrorCode.SocketError, "broken pipe")
+    event = make_state_changed_event("sensor.temperature", "21.5")
+
+    with (
+        patch("custom_components.qss.io._create_sender", return_value=sender),
+        patch("custom_components.qss.io.monotonic", side_effect=[0.0, 10.0]),
+    ):
+        connection = QuestDBConnection(_config(flush_interval_seconds=5))
+        connection.insert_event(event)
+        connection.flush_if_due()  # Must not raise.
+
+    assert connection._sender is None  # noqa: SLF001
+
+
+def test_connection_insert_event_retries_and_reconnects_on_transient_errors() -> None:
+    """A broken connection must be dropped and recreated until the insert succeeds."""
     attempts = {"count": 0}
+    good_sender = MagicMock()
 
-    class _FlakySender:
-        """Fails the first two connection attempts, then succeeds."""
-
-        def __enter__(self) -> MagicMock:
-            attempts["count"] += 1
-            if attempts["count"] < 3:
-                raise IngressError(IngressErrorCode.SocketError, "connection refused")
-            return MagicMock()
-
-        def __exit__(self, *_exc_info: object) -> bool:
-            return False
+    def _create_sender_side_effect(_config: QuestDBConfig) -> MagicMock:
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            bad_sender = MagicMock()
+            bad_sender.establish.side_effect = IngressError(
+                IngressErrorCode.SocketError, "connection refused"
+            )
+            return bad_sender
+        return good_sender
 
     event = make_state_changed_event("sensor.temperature", "21.5")
 
     with patch(
         "custom_components.qss.io._create_sender",
-        side_effect=lambda *a, **k: _FlakySender(),  # noqa: ARG005
+        side_effect=_create_sender_side_effect,
     ):
-        _retry_data_insertion(NO_AUTH_CONFIG, event)
+        connection = QuestDBConnection(_config())
+        connection.insert_event(event)
 
     assert attempts["count"] == 3
+    good_sender.row.assert_called_once()
+
+
+def test_connection_close_flushes_and_closes_sender() -> None:
+    """Closing the connection must flush buffered rows and close the sender."""
+    sender = MagicMock()
+    event = make_state_changed_event("sensor.temperature", "21.5")
+
+    with patch("custom_components.qss.io._create_sender", return_value=sender):
+        connection = QuestDBConnection(_config())
+        connection.insert_event(event)
+        connection.close()
+
+    sender.close.assert_called_once_with(flush=True)
+
+
+def test_connection_close_is_noop_when_never_connected() -> None:
+    """Closing a connection that never buffered anything must be a no-op."""
+    with patch("custom_components.qss.io._create_sender") as create_sender:
+        connection = QuestDBConnection(_config())
+        connection.close()  # Must not raise.
+
+    create_sender.assert_not_called()
+
+
+def test_connection_close_logs_and_swallows_ingress_error() -> None:
+    """A failure while closing must be logged, not raised."""
+    sender = MagicMock()
+    sender.close.side_effect = IngressError(IngressErrorCode.SocketError, "broken pipe")
+    event = make_state_changed_event("sensor.temperature", "21.5")
+
+    with patch("custom_components.qss.io._create_sender", return_value=sender):
+        connection = QuestDBConnection(_config())
+        connection.insert_event(event)
+        connection.close()  # Must not raise.
+
+    sender.close.assert_called_once_with(flush=True)
 
 
 def test_insert_event_data_into_questdb_marks_task_done_on_success() -> None:
@@ -136,10 +284,11 @@ def test_insert_event_data_into_questdb_marks_task_done_on_success() -> None:
     event_queue: queue.Queue = queue.Queue()
     event_queue.put("placeholder")
     event = make_state_changed_event("sensor.temperature", "21.5")
+    connection = MagicMock()
 
-    with patch("custom_components.qss.io._retry_data_insertion"):
-        insert_event_data_into_questdb(NO_AUTH_CONFIG, event, event_queue)
+    insert_event_data_into_questdb(connection, event, event_queue)
 
+    connection.insert_event.assert_called_once_with(event)
     event_queue.join()  # Must not block: proves task_done() was called.
 
 
@@ -148,11 +297,11 @@ def test_insert_event_data_into_questdb_marks_task_done_on_persistent_failure() 
     event_queue: queue.Queue = queue.Queue()
     event_queue.put("placeholder")
     event = make_state_changed_event("sensor.temperature", "21.5")
+    connection = MagicMock()
+    connection.insert_event.side_effect = IngressError(
+        IngressErrorCode.SocketError, "unreachable"
+    )
 
-    with patch(
-        "custom_components.qss.io._retry_data_insertion",
-        side_effect=IngressError(IngressErrorCode.SocketError, "unreachable"),
-    ):
-        insert_event_data_into_questdb(NO_AUTH_CONFIG, event, event_queue)
+    insert_event_data_into_questdb(connection, event, event_queue)
 
     event_queue.join()  # Must not block: proves task_done() was called.


### PR DESCRIPTION
## Summary

Replaces the per-event QuestDB connection pattern with a single long-lived, reused connection plus periodic/batched flushing, as requested.

Previously, `_retry_data_insertion` opened and closed a brand-new `questdb.ingress.Sender` (a new TCP/TCPS connection) for every single event. Under high event throughput this is wasteful. This PR introduces a `QuestDBConnection` class in `io.py` that owns a single `Sender`, created lazily on first use and reused across many events.

## What changed

- **`custom_components/qss/io.py`**: new `QuestDBConnection` class wrapping a lazily-created, reused `Sender`. Rows are buffered via `sender.row()` without an immediate flush. A flush happens when either `max_batch_size` rows are buffered or `flush_interval_seconds` have elapsed since the last flush, whichever comes first. `QuestDBConfig` gained `max_batch_size` / `flush_interval_seconds` fields.
- **`custom_components/qss/const.py`**: new `CONF_MAX_BATCH_SIZE` / `CONF_FLUSH_INTERVAL_SECONDS` config keys and `DEFAULT_MAX_BATCH_SIZE = 500` / `DEFAULT_FLUSH_INTERVAL_SECONDS = 5` defaults, following the same pattern as the recently-added `table_name` option.
- **`custom_components/qss/__init__.py`**: wired the two new optional `CONFIG_SCHEMA` keys through to `QuestDBConfig`. `QuestDB.run()` now creates a single `QuestDBConnection` for the thread's lifetime, polls the queue with `timeout=flush_interval_seconds`, and calls `connection.flush_if_due()` when idle so buffered rows don't sit unflushed indefinitely during quiet periods. A `try/finally` guarantees `connection.close()` (flush-then-close) runs on every exit path, including shutdown.
- **`custom_components/qss/event_handling.py`**: added a `QUEUE_POLL_TIMEOUT` sentinel and an optional `timeout` parameter to `get_event_from_queue`, distinct from the existing `None` shutdown sentinel.
- **Error handling**: a transient `IngressError` while inserting reconnects (drops and recreates the `Sender`) and retries via the existing tenacity-based retry pattern (`RETRY_ATTEMPTS`/`RETRY_WAIT_SECONDS`). A failure while flushing the idle buffer reconnects but does *not* retry, since any rows already buffered on a dropped connection can't be recovered by retrying the flush call itself (there's no event to re-buffer, unlike the insert path). `close()` is deliberately best-effort/non-retrying so shutdown is never blocked.
- **`README.md`**: documented `max_batch_size` and `flush_interval_seconds` in the configuration reference, matching the existing `table_name` entry style.
- **Tests**: `tests/test_io.py` reworked substantially for the new connection/batching model (lazy creation, connection reuse across events, batch-size-triggered flush, interval-triggered flush, reconnect-and-retry on transient errors, close semantics including the idle-connection no-op case). `tests/test_init.py` updated for the new `connection`-based wiring, plus new integration tests covering flush-then-close on shutdown and the idle poll-timeout flush path. `tests/test_event_handling.py` covers the new timeout sentinel.

## Verification

Run via WSL (Python 3.14, matching this branch's base):

- `poetry run pytest tests/ -q --cov=custom_components.qss --cov-report=term-missing` → **41 passed**, coverage **99%** (same as before this change; the one remaining uncovered line is a pre-existing, unrelated branch in `async_initialize`/`register`).
- `poetry run ruff check .` → all checks passed.
- `poetry run ruff format --check .` → all files already formatted.