### PR TITLE
Fix QuestDB JSON parse error caused by control characters

### DIFF
--- a/custom_components/qss/io.py
+++ b/custom_components/qss/io.py
@@ -1,10 +1,11 @@
 """Helper functions for IO operations on QuestDB."""
 
 import logging
+import re
 from dataclasses import dataclass, field
 from json import dumps
 from time import monotonic
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from questdb.ingress import IngressError, Protocol, Sender
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
@@ -23,6 +24,35 @@ if TYPE_CHECKING:
     from homeassistant.core import Event
 
 _LOGGER = logging.getLogger(__name__)
+
+# ASCII control characters that some entities occasionally emit as part of
+# their state or attribute values (e.g. raw sensor payloads or text
+# containing embedded newlines/escape sequences). The JSON spec requires all
+# of U+0000-U+001F (and U+007F) to be escaped inside a string, but QuestDB
+# has been observed to write these bytes verbatim into its JSON query
+# responses without escaping them, which then fails client-side JSON parsing
+# (see https://github.com/CM000n/qss/issues/230). They are stripped before
+# data is sent to QuestDB so stored values never contain them in the first
+# place, regardless of how QuestDB later serializes them.
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _strip_control_characters(value: str) -> str:
+    """Remove ASCII control characters that QuestDB may fail to JSON-escape."""
+    return _CONTROL_CHARS_RE.sub("", value)
+
+
+def _sanitize_value(value: Any) -> Any:  # noqa: ANN401
+    """Recursively strip control characters from any string in ``value``."""
+    if isinstance(value, str):
+        return _strip_control_characters(value)
+    if isinstance(value, dict):
+        return {key: _sanitize_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_sanitize_value(item) for item in value)
+    return value
 
 
 @dataclass(frozen=True)
@@ -74,12 +104,12 @@ def _insert_row(sender: Sender, event: Event, table_name: str) -> None:
     """
     entity_id = event.data["entity_id"]
     state = event.data.get("new_state")
-    attrs = dict(state.attributes)
+    attrs = _sanitize_value(dict(state.attributes))
     sender.row(
         table_name,
         symbols={"entity_id": entity_id},
         columns={
-            "state": state.state,
+            "state": _strip_control_characters(state.state),
             "attributes": dumps(attrs, sort_keys=True, default=str),
         },
         at=event.time_fired,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -98,6 +98,45 @@ def test_insert_row_writes_expected_row_without_flushing() -> None:
     sender.flush.assert_not_called()
 
 
+def test_insert_row_strips_control_characters_from_state() -> None:
+    """Control characters in the state must be stripped before sending.
+
+    QuestDB has been observed to write raw control characters verbatim into
+    its JSON query responses without escaping them, producing invalid JSON
+    that HA's frontend fails to parse (see
+    https://github.com/CM000n/qss/issues/230).
+    """
+    sender = MagicMock()
+    event = make_state_changed_event("sensor.text", "bad\x00\x1bstate\x7fend")
+
+    _insert_row(sender, event, "qss")
+
+    _, kwargs = sender.row.call_args
+    assert kwargs["columns"]["state"] == "badstateend"
+
+
+def test_insert_row_strips_control_characters_from_nested_attributes() -> None:
+    """Control characters nested in attribute strings/lists must be stripped."""
+    sender = MagicMock()
+    event = make_state_changed_event(
+        "sensor.text",
+        "ok",
+        attributes={
+            "note": "line1\nline2\x07",
+            "options": ["a\x01b", "c"],
+            "nested": {"deep": "value\x1f"},
+        },
+    )
+
+    _insert_row(sender, event, "qss")
+
+    _, kwargs = sender.row.call_args
+    attrs = loads(kwargs["columns"]["attributes"])
+    assert attrs["note"] == "line1line2"
+    assert attrs["options"] == ["ab", "c"]
+    assert attrs["nested"] == {"deep": "value"}
+
+
 def test_insert_row_uses_configured_table_name() -> None:
     """A custom table name should be forwarded to the sender as-is."""
     sender = MagicMock()


### PR DESCRIPTION
Fixes #230.

## Problem
Querying QuestDB (e.g. `SELECT timestamp, entityid, state FROM qss;`) can fail with:
`Invalid JSON response from the server: SyntaxError: JSON.parse: bad control character in string literal ...`

This happens because raw ASCII control characters occasionally end up in an entity's state or ttributes values (e.g. from noisy sensor payloads). JSON requires all of U+0000-U+001F (and U+007F) to be escaped inside a string, but QuestDB has been observed to write these bytes verbatim into its JSON query response without escaping them, breaking client-side JSON.parse and yielding an empty result set.

## Fix
Sanitize state.state and all string values inside ttributes (recursively, including nested dicts/lists) to strip these control characters before they are sent to QuestDB via ILP, so stored values can never produce invalid JSON when queried back.

## Testing
- Added unit tests covering control characters in both the top-level state and nested attributes.
- poetry run pytest (43 passed) and poetry run ruff check (all checks passed).